### PR TITLE
feat: Make terraform-image-tag parameter optional

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -1004,6 +1004,7 @@ jobs:
         type: string
       terraform-image-tag: # Unused and deprecated, but included to provide backwards compatibility
         type: string
+        default: ""
       setup-steps:
         type: steps
         default: []
@@ -1083,6 +1084,7 @@ jobs:
         type: string
       terraform-image-tag: # Unused and deprecated, but included to provide backwards compatibility
         type: string
+        default: ""
       setup-steps:
         type: steps
         default: []
@@ -1130,6 +1132,7 @@ jobs:
         type: string
       terraform-image-tag: # Unused and deprecated, but included to provide backwards compatibility
         type: string
+        default: ""
       setup-steps:
         type: steps
         default: []
@@ -1193,6 +1196,7 @@ jobs:
         type: string
       terraform-image-tag: # Unused and deprecated, but included to provide backwards compatibility
         type: string
+        default: ""
       github-access-token:
         type: string
       setup-steps:
@@ -1264,6 +1268,7 @@ jobs:
         type: string
       terraform-image-tag: # Unused and deprecated, but included to provide backwards compatibility
         type: string
+        default: ""
       github-access-token:
         type: string
       setup-steps:


### PR DESCRIPTION
The terraform-image-tag parameter is no longer used, so we make it optional to support new configurations that shouldn't have to specify it.